### PR TITLE
Make tests cleanup use findOne instead of findMany

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             PG_DB: $PG_DB
         docker:
             - image: circleci/node:12
-            - image: circleci/postgres:9.6-alpine-ram
+            - image: circleci/postgres:11-alpine
               environment:
                   DATABASE_URL: postgresql://postgres@localhost:5432/circle_test
         steps:

--- a/src/__tests__/Post.test.ts
+++ b/src/__tests__/Post.test.ts
@@ -82,8 +82,11 @@ const DELETE_POST = gql`
 `;
 
 beforeAll(async () => {
-    await prisma.post.deleteMany({ where: { title: 'Integration Test Post' } });
-    await prisma.user.deleteMany({ where: { email } });
+    const userExist = await prisma.user.findOne({ where: { email } });
+    if (userExist) {
+        await prisma.user.delete({ where: { email } });
+    }
+
     await prisma.user.create({
         data: {
             email,
@@ -95,8 +98,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-    await prisma.post.deleteMany({ where: { id: postId } });
-    await prisma.user.deleteMany({ where: { email } });
+    const postExist = await prisma.post.findOne({ where: { id: postId } });
+    if (postExist) {
+        await prisma.post.delete({ where: { id: postId } });
+    }
+
+    const userExist = await prisma.user.findOne({ where: { email } });
+    if (userExist) {
+        await prisma.user.delete({ where: { email } });
+    }
+
     await prisma.disconnect();
 });
 

--- a/src/__tests__/User.test.ts
+++ b/src/__tests__/User.test.ts
@@ -85,11 +85,17 @@ const UPDATE_USER = gql`
 `;
 
 beforeAll(async () => {
-    await prisma.user.deleteMany({ where: { email } });
+    const userExist = await prisma.user.findOne({ where: { email } });
+    if (userExist) {
+        await prisma.user.delete({ where: { email } });
+    }
 });
 
 afterAll(async () => {
-    await prisma.user.deleteMany({ where: { email } });
+    const userExist = await prisma.user.findOne({ where: { email } });
+    if (userExist) {
+        await prisma.user.delete({ where: { email } });
+    }
     await prisma.disconnect();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Request } from 'express';
 import { resolve } from 'path';
 import 'reflect-metadata';
 import { buildSchema } from 'type-graphql';
+import { SERVER_PORT } from './utils/constants';
 
 export interface Context {
     prisma: PrismaClient;
@@ -23,8 +24,8 @@ const main = async () => {
         playground: true,
         context: ({ req }) => ({ req, prisma } as Context),
     });
-    await server.listen(process.env.PORT);
-    console.log(`🚀 Server is running on http://localhost:${process.env.PORT}`);
+    await server.listen(SERVER_PORT);
+    console.log(`🚀 Server is running on http://localhost:${SERVER_PORT}`);
 };
 
 main().catch(console.error);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,6 +18,8 @@ export const GMAIL_USER: string = process.env.GMAIL!;
 
 export const GMAIL_PASSWORD: string = process.env.GMAIL_PASSWORD!;
 
+export const SERVER_PORT: string = process.env.SERVER_PORT || '4000';
+
 export const DEFAULT_LOGIN_QUERY = `# Enter your email and password to login to receive your access token
 mutation {
     login(email: "", password: "") {


### PR DESCRIPTION
Note:
- Issue with MacOS + Prisma
- When running on macOS -> `query-engine-darwin` is used
- While on Ubuntu -> `query-engine-debian-openssl-1.1.x` is used
- https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/query-engine